### PR TITLE
Add buddybuild as a CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
   <img src="https://github.com/GuyKahlon/RxStarscream/blob/master/SampleApp/Assets.xcassets/RxStarscreamIcon.imageset/RxStarscreamIcon.png" width="90" height="90"> 
 </p>
 
-
 RxStarscream with RxSwift 
 =========================================================================================================================
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=59143b0b0db7560001871050&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/59143b0b0db7560001871050/build/latest?branch=master)	
+
 A lightweight extension to [Starscream](https://github.com/daltoniam/Starscream) to track websocket events using RxSwift observables.
 
 ## Installation

--- a/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream.xcscheme
+++ b/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BEF3143F1E86D13C00C15DD4"
+               BuildableName = "RxStarscreamTests.xctest"
+               BlueprintName = "RxStarscreamTests"
+               ReferencedContainer = "container:RxStarscream.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E46D00251CFF22200054DF1F"
+            BuildableName = "RxStarscream.framework"
+            BlueprintName = "RxStarscream"
+            ReferencedContainer = "container:RxStarscream.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
This PR:
1. Adds a missing test target to the RxStarscream library
2. Adds buddybuild build status badge