### PR TITLE
Make write(ping:) and write(string:) public

### DIFF
--- a/Source/RxStarscream.swift
+++ b/Source/RxStarscream.swift
@@ -126,7 +126,7 @@ extension Reactive where Base: WebSocket {
         }
     }
 
-    func write(ping: Data) -> Observable<Void> {
+    public func write(ping: Data) -> Observable<Void> {
         return Observable.create { sub in
             self.base.write(ping: ping) {
                 sub.onNext(())
@@ -137,7 +137,7 @@ extension Reactive where Base: WebSocket {
         }
     }
 
-    func write(string: String) -> Observable<Void> {
+    public func write(string: String) -> Observable<Void> {
         return Observable.create { sub in
             self.base.write(string: string) {
                 sub.onNext(())


### PR DESCRIPTION
I fixed `write(ping:)` and `write(string:)` functions to public because they can not be used due to the internal level

## Reference
- [AccessControl](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/AccessControl.html)

> Default Access Levels
All entities in your code (with a few specific exceptions, as described later in this chapter) have a default access level of internal if you don’t specify an explicit access level yourself. As a result, in many cases you don’t need to specify an explicit access level in your code.

