### PR TITLE
Update to RxSwift v6.6.0 & Starscream v4.0.4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
             - v1-dep-
       - run:
           name: iOS, Swift 5
-          command: set -o pipefail && xcodebuild test SWIFT_VERSION=5.0 -scheme RxStarscream -project RxStarscream.xcodeproj -sdk iphonesimulator -destination "name=iPhone 8" |  xcpretty -c -r html --output $XCODE_TEST_REPORTS/iOS_swift5.html
+          command: set -o pipefail && xcodebuild test SWIFT_VERSION=5.0 -scheme RxStarscream -project RxStarscream.xcodeproj -sdk iphonesimulator -destination "name=iPhone 14" |  xcpretty -c -r html --output $XCODE_TEST_REPORTS/iOS_swift5.html
       - run:
           name: macOS, Swift 5
           command: set -o pipefail && xcodebuild test SWIFT_VERSION=5.0 -scheme RxStarscream-macOS -project RxStarscream.xcodeproj -sdk macosx | xcpretty -c -r html --output $XCODE_TEST_REPORTS/macOS_swift5.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       XCODE_TEST_REPORTS: /tmp/xcode-test-results
       LANG: en_US.UTF-8
     macos:
-      xcode: '10.2.0'
+      xcode: '14.3.1'
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS $XCODE_TEST_REPORTS
@@ -39,7 +39,7 @@ jobs:
     environment:
       LANG: en_US.UTF-8
     macos:
-      xcode: '10.2.0'
+      xcode: '14.3.1'
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,6 @@ jobs:
             - v1-dep-master-
             - v1-dep-
       - run:
-          name: Bootstrap Carthage
-          command: scripts/bootstrap.sh
-      - save_cache:
-          key: v1-dep-{{ .Branch }}-{{ epoch }}
-          paths:
-            - Carthage
-      - run:
           name: iOS, Swift 5
           command: set -o pipefail && xcodebuild test SWIFT_VERSION=5.0 -scheme RxStarscream -project RxStarscream.xcodeproj -sdk iphonesimulator -destination "name=iPhone 8" |  xcpretty -c -r html --output $XCODE_TEST_REPORTS/iOS_swift5.html
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,12 @@ DerivedData
 .idea/
 # Framworks
 *.framework
-
+# SPM
+Packages/
+Package.pins
+Package.resolved
+.swiftpm
+*.xcodeproj
 
 Carthage/Build
 Carthage/Checkouts

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-github "ReactiveX/RxSwift" ~> 5
-github "daltoniam/Starscream" ~> 3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "ReactiveX/RxSwift" "5.0.1"
-github "daltoniam/Starscream" "3.1.0"

--- a/Carthage/Cartfile.resolved
+++ b/Carthage/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "ReactiveX/RxSwift" "5.0.1"
-github "daltoniam/Starscream" "3.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RxStarscream",
+    platforms: [.iOS(.v12), .macOS(.v10_13)],
+    products: [
+        .library(
+            name: "RxStarscream",
+            targets: ["RxStarscream"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/daltoniam/Starscream", .upToNextMajor(from: "4.0.6")),
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.6.0"))
+    ],
+    targets: [
+        .target(
+            name: "RxStarscream",
+            dependencies: [
+                .product(name: "RxSwift", package: "RxSwift"),
+                .product(name: "RxCocoa", package: "RxSwift"),
+                .product(name: "RxRelay", package: "RxSwift"),
+                .product(name: "Starscream", package: "Starscream")
+            ],
+            path: "Source"),
+        .testTarget(
+            name: "RxStarscreamTests",
+            dependencies: [
+                .byName(name: "RxStarscream"),
+                .product(name: "RxTest", package: "RxSwift")
+            ],
+            path: "RxStarscreamTests"),
+        .testTarget(name: "RxStarscream_macOSTests",
+                    dependencies: [
+                        .byName(name: "RxStarscream"),
+                        .product(name: "RxTest", package: "RxSwift")
+                    ],
+                   path: "RxStarscream-macOSTests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# 🙋 Note: This project is my personal update to support SPM and the new version of Starscream.
+
 <p align="center">
   <img src="https://github.com/GuyKahlon/RxStarscream/blob/master/SampleApp/Assets.xcassets/RxStarscreamIcon.imageset/RxStarscreamIcon.png" width="90" height="90">
 </p>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ your Swift version.
 
 | Swift  | RxStarscream  | RxSwift       |
 | ------ | ------------- |---------------|
+| >= 5.0 |  \>= 0.11     |  \>= 6.6.0    |
 | >= 4.2 |  \>= 0.10     |  \>= 4.3      |
 | < 4.2  |  \>= 0.8      |  \>= 4.0      |
 | 3.X    |  0.7          | 3.0.0 - 3.6.1 |
@@ -43,6 +44,27 @@ Add this to your Cartfile
 Then run:
 
 	carthage update
+
+### Swift Package manager
+
+Create a `Package.swift`  file
+
+```
+let package = Package(
+        name: "SampleApp",
+
+        dependencies: [
+            .package(url: "https://github.com/RxSwiftCommunity/RxStarscream.git",
+                     from: "0.11.0"),
+        ],
+
+        targets: [
+            .target(
+                    name: "SampleApp",
+                    dependencies: ["RxStarscream"])
+        ]
+)
+```
 
 ## Usage examples
 
@@ -68,8 +90,8 @@ socket.rx.response.subscribe(onNext: { (response: WebSocketEvent) in
 		print("Connected")
 	case .disconnected(let error):
 		print("Disconnected with optional error : \(error)")
-	case .message(let msg):
-		print("Message : \(msg)")
+	case .text(let text):
+		print("Message : \(text)")
 	case .data(_):
 		print("Data")
 	case .pong:
@@ -98,7 +120,7 @@ socket.rx.text.subscribe(onNext: { (message: String) in
 
 ## Sample Project
 
-There's a sample project (you need to run `carthage update` for it to compile).
+There's a sample project with SPM.
 
 The sample project uses echo server - https://www.websocket.org/echo.html
 

--- a/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
+++ b/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
@@ -18,11 +18,11 @@ public func ==(lhs: WebSocketEvent, rhs: WebSocketEvent) -> Bool {
     switch (lhs, rhs) {
     case (.connected, .connected):
         return true
-    case (.disconnected(let lhsError), .disconnected(let rhsError)):
-        return lhsError?.localizedDescription == rhsError?.localizedDescription
-    case (.message(let lhsMsg), .message(let rhsMsg)):
-        return lhsMsg == rhsMsg
-    case (.data(let lhsData), .data(let rhsData)):
+    case (.disconnected, .disconnected):
+        return true
+    case (.text(let lhsText), .text(let rhsText)):
+        return lhsText == rhsText
+    case (.binary(let lhsData), .binary(let rhsData)):
         return lhsData == rhsData
     case (.pong, .pong):
         return true
@@ -43,7 +43,7 @@ class RxStarscreamTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        socket = WebSocket(url: URL(string: "wss://echo.websocket.org")!)
+        socket = WebSocket(request: URLRequest(url: URL(string: "wss://echo.websocket.org")!))
         continueAfterFailure = false
     }
 
@@ -62,28 +62,32 @@ class RxStarscreamTests: XCTestCase {
 
         XCTAssertTrue(socket.delegate != nil, "delegate should be set")
 
-        socket.delegate!.websocketDidConnect(socket: socket)
-        socket.delegate!.websocketDidDisconnect(socket: socket, error: nil)
+        socket.delegate!.didReceive(event: .connected([:]), client: socket)
+        socket.delegate!.didReceive(event: .disconnected("", UInt16.zero), client: socket)
 
         XCTAssertEqual(self.connectedObserver.events.count, 2)
         XCTAssertEqual(self.connectedObserver.events[0].value.element!, true)
         XCTAssertEqual(self.connectedObserver.events[1].value.element!, false)
     }
+    
+    //TODO: Binary test case.
 
     func testPongMessage() {
         let scheduler = TestScheduler(initialClock: 0)
         pongObserver = scheduler.createObserver(WebSocketEvent.self)
+        
+        let pongEvent = WebSocketEvent.pong(Data())
 
         socket.rx.response
             .subscribe(pongObserver)
             .disposed(by: disposeBag)
 
-        XCTAssertTrue(socket.pongDelegate != nil, "pongDelegate should be set")
+        XCTAssertNotNil(socket.delegate)
 
-        socket.pongDelegate!.websocketDidReceivePong(socket: socket, data: Data())
+        socket.delegate?.didReceive(event: pongEvent, client: socket)
 
         XCTAssertEqual(self.pongObserver.events.count, 1)
-        XCTAssertEqual(self.pongObserver.events[0].value.element!, WebSocketEvent.pong)
+        XCTAssertEqual(self.pongObserver.events[0].value.element!, pongEvent)
     }
 
     func testMessageResponse() {
@@ -98,10 +102,10 @@ class RxStarscreamTests: XCTestCase {
 
         XCTAssertTrue(socket.delegate != nil, "delegate should be set")
 
-        socket.delegate!.websocketDidReceiveMessage(socket: socket, text: sentMessage)
+        socket.delegate!.didReceive(event: .text(sentMessage), client: socket)
 
         XCTAssertEqual(self.responseObserver.events.count, 1)
-        XCTAssertEqual(WebSocketEvent.message(sentMessage), self.responseObserver.events[0].value.element!)
+        XCTAssertEqual(WebSocketEvent.text(sentMessage), self.responseObserver.events[0].value.element!)
     }
 }
 

--- a/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
+++ b/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxCocoa
 import RxTest
 import Starscream
-import RxStarscream
+import RxStarscream_macOS
 
 extension WebSocketEvent: Equatable { }
 

--- a/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
+++ b/RxStarscream-macOSTests/RxStarscream_macOSTests.swift
@@ -8,9 +8,10 @@
 
 import XCTest
 import RxSwift
+import RxCocoa
 import RxTest
 import Starscream
-import RxStarscream_macOS
+import RxStarscream
 
 extension WebSocketEvent: Equatable { }
 

--- a/RxStarscream.podspec
+++ b/RxStarscream.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'RxStarscream'
-  spec.version          = '0.10'
+  spec.version          = '0.20'
   spec.license          = 'Apache License, Version 2.0'
   spec.homepage         = 'https://github.com/RxSwiftCommunity/RxStarscream'
   spec.authors          = { 'Guy Kahlon' => 'guykahlon@gmail.com' }
@@ -8,11 +8,11 @@ Pod::Spec.new do |spec|
   spec.source           = { :git => 'https://github.com/RxSwiftCommunity/RxStarscream.git', :tag => spec.version.to_s }
   spec.source_files     = 'Source/*.swift'
   spec.requires_arc     = true
-  spec.ios.deployment_target = '8.0'
-  spec.osx.deployment_target = '10.10'
-  spec.dependency 'Starscream', '~> 3'
-  spec.dependency 'RxSwift', '~> 5'
-  spec.dependency 'RxCocoa', '~> 5'
+  spec.ios.deployment_target = '12.0'
+  spec.osx.deployment_target = '10.13'
+  spec.dependency 'Starscream', '~> 4.0.6'
+  spec.dependency 'RxSwift', '~> 6.6.0'
+  spec.dependency 'RxCocoa', '~> 6.6.0'
   spec.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -3,61 +3,31 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B4DAAC71E0497BC00ECDBF9 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */; };
-		0B4DAAC81E04980000ECDBF9 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */; };
-		0B4DAAC91E04980000ECDBF9 /* RxCocoa.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		98655E3C204F892000524A64 /* RxStarscream_macOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98D95A3F204F7E9A00159C45 /* RxStarscream_macOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		98D95A48204F7E9B00159C45 /* RxStarscream_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A3F204F7E9A00159C45 /* RxStarscream_macOS.framework */; };
 		98D95A56204F7EB400159C45 /* RxStarscream_macOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D95A41204F7E9A00159C45 /* RxStarscream_macOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		98D95A57204F7EC000159C45 /* RxStarscream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46D00311CFF22760054DF1F /* RxStarscream.swift */; };
-		98D95A59204F7EDF00159C45 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A58204F7EDE00159C45 /* RxSwift.framework */; };
-		98D95A5D204F7EF800159C45 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A5C204F7EF800159C45 /* Starscream.framework */; };
-		98D95A5F204F7FC300159C45 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A5A204F7EEE00159C45 /* RxCocoa.framework */; };
 		98D95A61204F82BA00159C45 /* RxStarscream_macOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D95A4C204F7E9B00159C45 /* RxStarscream_macOSTests.swift */; };
-		98D95A62204F839A00159C45 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A5A204F7EEE00159C45 /* RxCocoa.framework */; };
-		98D95A63204F83A400159C45 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A58204F7EDE00159C45 /* RxSwift.framework */; };
-		98D95A65204F83AE00159C45 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A64204F83AE00159C45 /* RxTest.framework */; };
-		98D95A67204F85D000159C45 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D95A5C204F7EF800159C45 /* Starscream.framework */; };
+		A31120882B1ACE330027DA34 /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = A31120872B1ACE330027DA34 /* RxBlocking */; };
+		A311208A2B1ACE330027DA34 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A31120892B1ACE330027DA34 /* RxCocoa */; };
+		A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A311208B2B1ACE330027DA34 /* RxRelay */; };
+		A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A311208D2B1ACE330027DA34 /* RxSwift */; };
+		A31120932B1ACE410027DA34 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A31120922B1ACE410027DA34 /* Starscream */; };
 		BEF314431E86D13C00C15DD4 /* RxStarscreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF314421E86D13C00C15DD4 /* RxStarscreamTests.swift */; };
 		BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; };
-		BEF314521E86DB5700C15DD4 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A21CFF275E00885498 /* RxSwift.framework */; };
-		BEF314541E86DB5700C15DD4 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEF3144C1E86DAFA00C15DD4 /* RxTest.framework */; };
-		BEF314551E86DB5700C15DD4 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A31CFF275E00885498 /* Starscream.framework */; };
-		BEF314571E875D8500C15DD4 /* RxCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BEF314581E875D8500C15DD4 /* RxSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E42144A21CFF275E00885498 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BEF314591E875D8500C15DD4 /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E42144A31CFF275E00885498 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BEF3145B1E875DAA00C15DD4 /* RxTest.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BEF3144C1E86DAFA00C15DD4 /* RxTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E402203A1CFF3C6900C5A874 /* RxSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A21CFF275E00885498 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E402203C1CFF3C6900C5A874 /* Starscream.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A31CFF275E00885498 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E42144A41CFF275E00885498 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A21CFF275E00885498 /* RxSwift.framework */; };
-		E42144A51CFF275E00885498 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A31CFF275E00885498 /* Starscream.framework */; };
 		E42144DD1CFF385E00885498 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42144DC1CFF385E00885498 /* AppDelegate.swift */; };
 		E42144DF1CFF385E00885498 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42144DE1CFF385E00885498 /* ViewController.swift */; };
 		E42144E21CFF385E00885498 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E42144E01CFF385E00885498 /* Main.storyboard */; };
 		E42144E41CFF385E00885498 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E42144E31CFF385E00885498 /* Assets.xcassets */; };
 		E42144E71CFF385E00885498 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E42144E51CFF385E00885498 /* LaunchScreen.storyboard */; };
 		E42144EC1CFF395500885498 /* RxStarscream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46D00311CFF22760054DF1F /* RxStarscream.swift */; };
-		E42144ED1CFF3AC600885498 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A21CFF275E00885498 /* RxSwift.framework */; };
-		E42144EE1CFF3AC900885498 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E42144A31CFF275E00885498 /* Starscream.framework */; };
 		E46D002A1CFF22200054DF1F /* RxStarscream.h in Headers */ = {isa = PBXBuildFile; fileRef = E46D00291CFF22200054DF1F /* RxStarscream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E46D00321CFF22760054DF1F /* RxStarscream.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46D00311CFF22760054DF1F /* RxStarscream.swift */; };
-		EE32F632227B251800F27FFA /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F631227B251800F27FFA /* RxRelay.framework */; };
-		EE32F633227B253200F27FFA /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F631227B251800F27FFA /* RxRelay.framework */; };
-		EE32F639227B257600F27FFA /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F638227B257600F27FFA /* RxRelay.framework */; };
-		EE32F63A227B258500F27FFA /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F638227B257600F27FFA /* RxRelay.framework */; };
-		EE32F640227B28A500F27FFA /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F631227B251800F27FFA /* RxRelay.framework */; };
-		EE32F641227B28E700F27FFA /* RxRelay.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EE32F631227B251800F27FFA /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F642227B292400F27FFA /* RxRelay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EE32F631227B251800F27FFA /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F643227B296300F27FFA /* RxCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98D95A5A204F7EEE00159C45 /* RxCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F644227B296300F27FFA /* RxRelay.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = EE32F638227B257600F27FFA /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F645227B296300F27FFA /* RxSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98D95A58204F7EDE00159C45 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F646227B296300F27FFA /* RxTest.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98D95A64204F83AE00159C45 /* RxTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EE32F647227B296300F27FFA /* Starscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98D95A5C204F7EF800159C45 /* Starscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,12 +54,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				EE32F643227B296300F27FFA /* RxCocoa.framework in CopyFiles */,
-				EE32F644227B296300F27FFA /* RxRelay.framework in CopyFiles */,
 				98655E3C204F892000524A64 /* RxStarscream_macOS.framework in CopyFiles */,
-				EE32F645227B296300F27FFA /* RxSwift.framework in CopyFiles */,
-				EE32F646227B296300F27FFA /* RxTest.framework in CopyFiles */,
-				EE32F647227B296300F27FFA /* Starscream.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,12 +64,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BEF314571E875D8500C15DD4 /* RxCocoa.framework in CopyFiles */,
-				EE32F641227B28E700F27FFA /* RxRelay.framework in CopyFiles */,
 				DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */,
-				BEF314581E875D8500C15DD4 /* RxSwift.framework in CopyFiles */,
-				BEF3145B1E875DAA00C15DD4 /* RxTest.framework in CopyFiles */,
-				BEF314591E875D8500C15DD4 /* Starscream.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,10 +74,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				0B4DAAC91E04980000ECDBF9 /* RxCocoa.framework in Embed Frameworks */,
-				EE32F642227B292400F27FFA /* RxRelay.framework in Embed Frameworks */,
-				E402203A1CFF3C6900C5A874 /* RxSwift.framework in Embed Frameworks */,
-				E402203C1CFF3C6900C5A874 /* Starscream.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -125,24 +81,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/iOS/RxCocoa.framework; sourceTree = "<group>"; };
 		98D95A3F204F7E9A00159C45 /* RxStarscream_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxStarscream_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D95A41204F7E9A00159C45 /* RxStarscream_macOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxStarscream_macOS.h; sourceTree = "<group>"; };
 		98D95A42204F7E9B00159C45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		98D95A47204F7E9B00159C45 /* RxStarscream-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxStarscream-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D95A4C204F7E9B00159C45 /* RxStarscream_macOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxStarscream_macOSTests.swift; sourceTree = "<group>"; };
 		98D95A4E204F7E9B00159C45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		98D95A58204F7EDE00159C45 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/Mac/RxSwift.framework; sourceTree = "<group>"; };
-		98D95A5A204F7EEE00159C45 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = Carthage/Build/Mac/RxCocoa.framework; sourceTree = "<group>"; };
-		98D95A5C204F7EF800159C45 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/Mac/Starscream.framework; sourceTree = "<group>"; };
-		98D95A64204F83AE00159C45 /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/Mac/RxTest.framework; sourceTree = "<group>"; };
 		BEF314401E86D13C00C15DD4 /* RxStarscreamTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxStarscreamTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEF314421E86D13C00C15DD4 /* RxStarscreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxStarscreamTests.swift; sourceTree = "<group>"; };
 		BEF314441E86D13C00C15DD4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BEF3144C1E86DAFA00C15DD4 /* RxTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxTest.framework; path = Carthage/Build/iOS/RxTest.framework; sourceTree = "<group>"; };
-		BEF3144E1E86DB0700C15DD4 /* iOS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = iOS; path = Carthage/Build/iOS; sourceTree = "<group>"; };
-		E42144A21CFF275E00885498 /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxSwift.framework; path = Carthage/Build/iOS/RxSwift.framework; sourceTree = "<group>"; };
-		E42144A31CFF275E00885498 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 		E42144DA1CFF385E00885498 /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E42144DC1CFF385E00885498 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E42144DE1CFF385E00885498 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -154,8 +101,6 @@
 		E46D00291CFF22200054DF1F /* RxStarscream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxStarscream.h; sourceTree = "<group>"; };
 		E46D002B1CFF22200054DF1F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E46D00311CFF22760054DF1F /* RxStarscream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RxStarscream.swift; path = Source/RxStarscream.swift; sourceTree = SOURCE_ROOT; };
-		EE32F631227B251800F27FFA /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/iOS/RxRelay.framework; sourceTree = "<group>"; };
-		EE32F638227B257600F27FFA /* RxRelay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxRelay.framework; path = Carthage/Build/Mac/RxRelay.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,10 +108,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				98D95A5F204F7FC300159C45 /* RxCocoa.framework in Frameworks */,
-				EE32F639227B257600F27FFA /* RxRelay.framework in Frameworks */,
-				98D95A59204F7EDF00159C45 /* RxSwift.framework in Frameworks */,
-				98D95A5D204F7EF800159C45 /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -174,12 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				98D95A62204F839A00159C45 /* RxCocoa.framework in Frameworks */,
-				EE32F63A227B258500F27FFA /* RxRelay.framework in Frameworks */,
 				98D95A48204F7E9B00159C45 /* RxStarscream_macOS.framework in Frameworks */,
-				98D95A63204F83A400159C45 /* RxSwift.framework in Frameworks */,
-				98D95A65204F83AE00159C45 /* RxTest.framework in Frameworks */,
-				98D95A67204F85D000159C45 /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -187,11 +123,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE32F640227B28A500F27FFA /* RxRelay.framework in Frameworks */,
 				BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */,
-				BEF314521E86DB5700C15DD4 /* RxSwift.framework in Frameworks */,
-				BEF314541E86DB5700C15DD4 /* RxTest.framework in Frameworks */,
-				BEF314551E86DB5700C15DD4 /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -199,10 +131,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B4DAAC81E04980000ECDBF9 /* RxCocoa.framework in Frameworks */,
-				EE32F633227B253200F27FFA /* RxRelay.framework in Frameworks */,
-				E42144ED1CFF3AC600885498 /* RxSwift.framework in Frameworks */,
-				E42144EE1CFF3AC900885498 /* Starscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -210,10 +138,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B4DAAC71E0497BC00ECDBF9 /* RxCocoa.framework in Frameworks */,
-				EE32F632227B251800F27FFA /* RxRelay.framework in Frameworks */,
-				E42144A41CFF275E00885498 /* RxSwift.framework in Frameworks */,
-				E42144A51CFF275E00885498 /* Starscream.framework in Frameworks */,
+				A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */,
+				A311208A2B1ACE330027DA34 /* RxCocoa in Frameworks */,
+				A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */,
+				A31120882B1ACE330027DA34 /* RxBlocking in Frameworks */,
+				A31120932B1ACE410027DA34 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -247,31 +176,6 @@
 			path = RxStarscreamTests;
 			sourceTree = "<group>";
 		};
-		BEF3144B1E86DAF900C15DD4 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				BEF3144E1E86DB0700C15DD4 /* iOS */,
-				98D95A5A204F7EEE00159C45 /* RxCocoa.framework */,
-				EE32F638227B257600F27FFA /* RxRelay.framework */,
-				98D95A58204F7EDE00159C45 /* RxSwift.framework */,
-				98D95A64204F83AE00159C45 /* RxTest.framework */,
-				98D95A5C204F7EF800159C45 /* Starscream.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E42144A61CFF27C800885498 /* Dependency Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				0B4DAAC61E0497BC00ECDBF9 /* RxCocoa.framework */,
-				EE32F631227B251800F27FFA /* RxRelay.framework */,
-				E42144A21CFF275E00885498 /* RxSwift.framework */,
-				BEF3144C1E86DAFA00C15DD4 /* RxTest.framework */,
-				E42144A31CFF275E00885498 /* Starscream.framework */,
-			);
-			name = "Dependency Frameworks";
-			sourceTree = "<group>";
-		};
 		E42144DB1CFF385E00885498 /* SampleApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -294,8 +198,6 @@
 				98D95A40204F7E9A00159C45 /* RxStarscream-macOS */,
 				98D95A4B204F7E9B00159C45 /* RxStarscream-macOSTests */,
 				E46D00271CFF22200054DF1F /* Products */,
-				E42144A61CFF27C800885498 /* Dependency Frameworks */,
-				BEF3144B1E86DAF900C15DD4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -431,6 +333,13 @@
 			dependencies = (
 			);
 			name = RxStarscream;
+			packageProductDependencies = (
+				A31120872B1ACE330027DA34 /* RxBlocking */,
+				A31120892B1ACE330027DA34 /* RxCocoa */,
+				A311208B2B1ACE330027DA34 /* RxRelay */,
+				A311208D2B1ACE330027DA34 /* RxSwift */,
+				A31120922B1ACE410027DA34 /* Starscream */,
+			);
 			productName = RxStarscream;
 			productReference = E46D00261CFF22200054DF1F /* RxStarscream.framework */;
 			productType = "com.apple.product-type.framework";
@@ -483,6 +392,10 @@
 				Base,
 			);
 			mainGroup = E46D001C1CFF22200054DF1F;
+			packageReferences = (
+				A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */,
+				A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */,
+			);
 			productRefGroup = E46D00271CFF22200054DF1F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -637,7 +550,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -670,7 +587,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -697,7 +618,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOSTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -724,7 +649,11 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOSTests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -746,7 +675,11 @@
 				);
 				INFOPLIST_FILE = RxStarscreamTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.RxStarscreamTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -767,10 +700,15 @@
 				);
 				INFOPLIST_FILE = RxStarscreamTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.RxStarscreamTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -787,7 +725,10 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = SampleApp/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -809,7 +750,10 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = SampleApp/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.SampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -867,7 +811,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -922,11 +866,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -952,7 +897,11 @@
 				);
 				INFOPLIST_FILE = RxStarscream/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.RxStarscream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -979,7 +928,11 @@
 				);
 				INFOPLIST_FILE = RxStarscream/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.RxSwift.RxStarscream;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1046,6 +999,53 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift";
+			requirement = {
+				kind = exactVersion;
+				version = 6.6.0;
+			};
+		};
+		A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/daltoniam/Starscream";
+			requirement = {
+				kind = exactVersion;
+				version = 4.0.6;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A31120872B1ACE330027DA34 /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
+		};
+		A31120892B1ACE330027DA34 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		A311208B2B1ACE330027DA34 /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		A311208D2B1ACE330027DA34 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		A31120922B1ACE410027DA34 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E46D001D1CFF22200054DF1F /* Project object */;
 }

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -384,10 +384,9 @@
 			};
 			buildConfigurationList = E46D00201CFF22200054DF1F /* Build configuration list for PBXProject "RxStarscream" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);
@@ -891,10 +890,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RxStarscream/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -922,10 +918,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RxStarscream/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		A38CE3542B1B6F4A00AEAFB3 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3532B1B6F4A00AEAFB3 /* RxSwift */; };
 		A38CE3562B1B6F8300AEAFB3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3552B1B6F8300AEAFB3 /* Starscream */; };
 		A38CE3582B1B704000AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3572B1B704000AEAFB3 /* RxTest */; };
+		A38CE35A2B1CF8F200AEAFB3 /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3592B1CF8F200AEAFB3 /* RxBlocking */; };
+		A38CE35C2B1CF8F200AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE35B2B1CF8F200AEAFB3 /* RxCocoa */; };
+		A38CE35E2B1CF8F200AEAFB3 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE35D2B1CF8F200AEAFB3 /* RxRelay */; };
+		A38CE3602B1CF8F200AEAFB3 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE35F2B1CF8F200AEAFB3 /* RxSwift */; };
+		A38CE3622B1CF8F200AEAFB3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3612B1CF8F200AEAFB3 /* Starscream */; };
 		BEF314431E86D13C00C15DD4 /* RxStarscreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF314421E86D13C00C15DD4 /* RxStarscreamTests.swift */; };
 		BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; };
 		DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -145,6 +150,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A38CE35E2B1CF8F200AEAFB3 /* RxRelay in Frameworks */,
+				A38CE35C2B1CF8F200AEAFB3 /* RxCocoa in Frameworks */,
+				A38CE3602B1CF8F200AEAFB3 /* RxSwift in Frameworks */,
+				A38CE3622B1CF8F200AEAFB3 /* Starscream in Frameworks */,
+				A38CE35A2B1CF8F200AEAFB3 /* RxBlocking in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -350,6 +360,13 @@
 			dependencies = (
 			);
 			name = SampleApp;
+			packageProductDependencies = (
+				A38CE3592B1CF8F200AEAFB3 /* RxBlocking */,
+				A38CE35B2B1CF8F200AEAFB3 /* RxCocoa */,
+				A38CE35D2B1CF8F200AEAFB3 /* RxRelay */,
+				A38CE35F2B1CF8F200AEAFB3 /* RxSwift */,
+				A38CE3612B1CF8F200AEAFB3 /* Starscream */,
+			);
 			productName = SampleApp;
 			productReference = E42144DA1CFF385E00885498 /* SampleApp.app */;
 			productType = "com.apple.product-type.application";
@@ -1095,6 +1112,31 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = RxTest;
+		};
+		A38CE3592B1CF8F200AEAFB3 /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
+		};
+		A38CE35B2B1CF8F200AEAFB3 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		A38CE35D2B1CF8F200AEAFB3 /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		A38CE35F2B1CF8F200AEAFB3 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		A38CE3612B1CF8F200AEAFB3 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -17,6 +17,13 @@
 		A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A311208B2B1ACE330027DA34 /* RxRelay */; };
 		A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A311208D2B1ACE330027DA34 /* RxSwift */; };
 		A31120932B1ACE410027DA34 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A31120922B1ACE410027DA34 /* Starscream */; };
+		A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in CopyFiles */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34D2B1B6EB400AEAFB3 /* RxTest */; };
+		A38CE3502B1B6F4A00AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */; };
+		A38CE3522B1B6F4A00AEAFB3 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3512B1B6F4A00AEAFB3 /* RxRelay */; };
+		A38CE3542B1B6F4A00AEAFB3 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3532B1B6F4A00AEAFB3 /* RxSwift */; };
+		A38CE3562B1B6F8300AEAFB3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3552B1B6F8300AEAFB3 /* Starscream */; };
+		A38CE3582B1B704000AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3572B1B704000AEAFB3 /* RxTest */; };
 		BEF314431E86D13C00C15DD4 /* RxStarscreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF314421E86D13C00C15DD4 /* RxStarscreamTests.swift */; };
 		BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; };
 		DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -64,6 +71,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in CopyFiles */,
 				DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -108,6 +116,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A38CE3542B1B6F4A00AEAFB3 /* RxSwift in Frameworks */,
+				A38CE3522B1B6F4A00AEAFB3 /* RxRelay in Frameworks */,
+				A38CE3502B1B6F4A00AEAFB3 /* RxCocoa in Frameworks */,
+				A38CE3562B1B6F8300AEAFB3 /* Starscream in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +127,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A38CE3582B1B704000AEAFB3 /* RxTest in Frameworks */,
 				98D95A48204F7E9B00159C45 /* RxStarscream_macOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -123,6 +136,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */,
 				BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,6 +181,13 @@
 			path = "RxStarscream-macOSTests";
 			sourceTree = "<group>";
 		};
+		A38CE3492B1B6E6D00AEAFB3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BEF314411E86D13C00C15DD4 /* RxStarscreamTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -198,6 +219,7 @@
 				98D95A40204F7E9A00159C45 /* RxStarscream-macOS */,
 				98D95A4B204F7E9B00159C45 /* RxStarscream-macOSTests */,
 				E46D00271CFF22200054DF1F /* Products */,
+				A38CE3492B1B6E6D00AEAFB3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -259,6 +281,12 @@
 			dependencies = (
 			);
 			name = "RxStarscream-macOS";
+			packageProductDependencies = (
+				A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */,
+				A38CE3512B1B6F4A00AEAFB3 /* RxRelay */,
+				A38CE3532B1B6F4A00AEAFB3 /* RxSwift */,
+				A38CE3552B1B6F8300AEAFB3 /* Starscream */,
+			);
 			productName = "RxStarscream-macOS";
 			productReference = 98D95A3F204F7E9A00159C45 /* RxStarscream_macOS.framework */;
 			productType = "com.apple.product-type.framework";
@@ -278,6 +306,9 @@
 				98D95A4A204F7E9B00159C45 /* PBXTargetDependency */,
 			);
 			name = "RxStarscream-macOSTests";
+			packageProductDependencies = (
+				A38CE3572B1B704000AEAFB3 /* RxTest */,
+			);
 			productName = "RxStarscream-macOSTests";
 			productReference = 98D95A47204F7E9B00159C45 /* RxStarscream-macOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -297,6 +328,10 @@
 				BEF314471E86D13C00C15DD4 /* PBXTargetDependency */,
 			);
 			name = RxStarscreamTests;
+			packageProductDependencies = (
+				A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */,
+				A38CE34D2B1B6EB400AEAFB3 /* RxTest */,
+			);
 			productName = RxStarscreamTests;
 			productReference = BEF314401E86D13C00C15DD4 /* RxStarscreamTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -541,10 +576,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOS/Info.plist";
@@ -554,7 +586,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -578,10 +610,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "RxStarscream-macOS/Info.plist";
@@ -591,7 +620,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = macosx;
@@ -622,7 +651,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -653,7 +682,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.RxSwift.RxStarscream-macOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -668,12 +697,9 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RxStarscreamTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -693,12 +719,9 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				DEVELOPMENT_TEAM = 7GE4Q65N57;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RxStarscreamTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1037,6 +1060,41 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
+		};
+		A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = "RxTest-Dynamic";
+		};
+		A38CE34D2B1B6EB400AEAFB3 /* RxTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxTest;
+		};
+		A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		A38CE3512B1B6F4A00AEAFB3 /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		A38CE3532B1B6F4A00AEAFB3 /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+		A38CE3552B1B6F8300AEAFB3 /* Starscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
+			productName = Starscream;
+		};
+		A38CE3572B1B704000AEAFB3 /* RxTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxTest;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -17,8 +17,7 @@
 		A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A311208B2B1ACE330027DA34 /* RxRelay */; };
 		A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A311208D2B1ACE330027DA34 /* RxSwift */; };
 		A31120932B1ACE410027DA34 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A31120922B1ACE410027DA34 /* Starscream */; };
-		A36A15202B22EFB600564C10 /* RxTest-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; };
-		A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in CopyFiles */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in Copy Files */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34D2B1B6EB400AEAFB3 /* RxTest */; };
 		A38CE3502B1B6F4A00AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */; };
 		A38CE3522B1B6F4A00AEAFB3 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3512B1B6F4A00AEAFB3 /* RxRelay */; };
@@ -32,7 +31,7 @@
 		A38CE3622B1CF8F200AEAFB3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3612B1CF8F200AEAFB3 /* Starscream */; };
 		BEF314431E86D13C00C15DD4 /* RxStarscreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEF314421E86D13C00C15DD4 /* RxStarscreamTests.swift */; };
 		BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; };
-		DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DF3045271FF31E5E009A779B /* RxStarscream.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = E46D00261CFF22200054DF1F /* RxStarscream.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E42144DD1CFF385E00885498 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42144DC1CFF385E00885498 /* AppDelegate.swift */; };
 		E42144DF1CFF385E00885498 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42144DE1CFF385E00885498 /* ViewController.swift */; };
 		E42144E21CFF385E00885498 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E42144E01CFF385E00885498 /* Main.storyboard */; };
@@ -71,15 +70,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BEF314561E875D5F00C15DD4 /* CopyFiles */ = {
+		BEF314561E875D5F00C15DD4 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in CopyFiles */,
-				DF3045271FF31E5E009A779B /* RxStarscream.framework in CopyFiles */,
+				A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in Copy Files */,
+				DF3045271FF31E5E009A779B /* RxStarscream.framework in Copy Files */,
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E402203D1CFF3C6900C5A874 /* Embed Frameworks */ = {
@@ -142,7 +142,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A36A15202B22EFB600564C10 /* RxTest-Dynamic in Frameworks */,
 				A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */,
 				BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */,
 			);
@@ -332,7 +331,7 @@
 				BEF3143C1E86D13C00C15DD4 /* Sources */,
 				BEF3143D1E86D13C00C15DD4 /* Frameworks */,
 				BEF3143E1E86D13C00C15DD4 /* Resources */,
-				BEF314561E875D5F00C15DD4 /* CopyFiles */,
+				BEF314561E875D5F00C15DD4 /* Copy Files */,
 			);
 			buildRules = (
 			);

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A311208B2B1ACE330027DA34 /* RxRelay */; };
 		A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A311208D2B1ACE330027DA34 /* RxSwift */; };
 		A31120932B1ACE410027DA34 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A31120922B1ACE410027DA34 /* Starscream */; };
+		A36A15202B22EFB600564C10 /* RxTest-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; };
 		A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in CopyFiles */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34D2B1B6EB400AEAFB3 /* RxTest */; };
 		A38CE3502B1B6F4A00AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */; };
@@ -141,6 +142,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A36A15202B22EFB600564C10 /* RxTest-Dynamic in Frameworks */,
 				A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */,
 				BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */,
 			);
@@ -851,7 +853,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -906,7 +908,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/RxStarscream.xcodeproj/project.pbxproj
+++ b/RxStarscream.xcodeproj/project.pbxproj
@@ -17,13 +17,14 @@
 		A311208C2B1ACE330027DA34 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A311208B2B1ACE330027DA34 /* RxRelay */; };
 		A311208E2B1ACE330027DA34 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A311208D2B1ACE330027DA34 /* RxSwift */; };
 		A31120932B1ACE410027DA34 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A31120922B1ACE410027DA34 /* Starscream */; };
+		A36A15232B278D9C00564C10 /* RxTest-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; };
+		A36A15252B278DB400564C10 /* RxTest-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A36A15242B278DB400564C10 /* RxTest-Dynamic */; };
+		A36A15262B278DB400564C10 /* RxTest-Dynamic in CopyFiles */ = {isa = PBXBuildFile; productRef = A36A15242B278DB400564C10 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		A38CE34C2B1B6E6D00AEAFB3 /* RxTest-Dynamic in Copy Files */ = {isa = PBXBuildFile; productRef = A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34D2B1B6EB400AEAFB3 /* RxTest */; };
 		A38CE3502B1B6F4A00AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */; };
 		A38CE3522B1B6F4A00AEAFB3 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3512B1B6F4A00AEAFB3 /* RxRelay */; };
 		A38CE3542B1B6F4A00AEAFB3 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3532B1B6F4A00AEAFB3 /* RxSwift */; };
 		A38CE3562B1B6F8300AEAFB3 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3552B1B6F8300AEAFB3 /* Starscream */; };
-		A38CE3582B1B704000AEAFB3 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3572B1B704000AEAFB3 /* RxTest */; };
 		A38CE35A2B1CF8F200AEAFB3 /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE3592B1CF8F200AEAFB3 /* RxBlocking */; };
 		A38CE35C2B1CF8F200AEAFB3 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE35B2B1CF8F200AEAFB3 /* RxCocoa */; };
 		A38CE35E2B1CF8F200AEAFB3 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A38CE35D2B1CF8F200AEAFB3 /* RxRelay */; };
@@ -66,6 +67,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				A36A15262B278DB400564C10 /* RxTest-Dynamic in CopyFiles */,
 				98655E3C204F892000524A64 /* RxStarscream_macOS.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -133,7 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A38CE3582B1B704000AEAFB3 /* RxTest in Frameworks */,
+				A36A15252B278DB400564C10 /* RxTest-Dynamic in Frameworks */,
 				98D95A48204F7E9B00159C45 /* RxStarscream_macOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -142,7 +144,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A38CE34E2B1B6EB400AEAFB3 /* RxTest in Frameworks */,
+				A36A15232B278D9C00564C10 /* RxTest-Dynamic in Frameworks */,
 				BEF314451E86D13C00C15DD4 /* RxStarscream.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -318,7 +320,7 @@
 			);
 			name = "RxStarscream-macOSTests";
 			packageProductDependencies = (
-				A38CE3572B1B704000AEAFB3 /* RxTest */,
+				A36A15242B278DB400564C10 /* RxTest-Dynamic */,
 			);
 			productName = "RxStarscream-macOSTests";
 			productReference = 98D95A47204F7E9B00159C45 /* RxStarscream-macOSTests.xctest */;
@@ -341,7 +343,6 @@
 			name = RxStarscreamTests;
 			packageProductDependencies = (
 				A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */,
-				A38CE34D2B1B6EB400AEAFB3 /* RxTest */,
 			);
 			productName = RxStarscreamTests;
 			productReference = BEF314401E86D13C00C15DD4 /* RxStarscreamTests.xctest */;
@@ -1079,15 +1080,15 @@
 			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
 		};
-		A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */ = {
+		A36A15242B278DB400564C10 /* RxTest-Dynamic */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
 			productName = "RxTest-Dynamic";
 		};
-		A38CE34D2B1B6EB400AEAFB3 /* RxTest */ = {
+		A38CE34A2B1B6E6D00AEAFB3 /* RxTest-Dynamic */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxTest;
+			productName = "RxTest-Dynamic";
 		};
 		A38CE34F2B1B6F4A00AEAFB3 /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1108,11 +1109,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A31120912B1ACE410027DA34 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
-		};
-		A38CE3572B1B704000AEAFB3 /* RxTest */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A31120862B1ACE330027DA34 /* XCRemoteSwiftPackageReference "RxSwift" */;
-			productName = RxTest;
 		};
 		A38CE3592B1CF8F200AEAFB3 /* RxBlocking */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RxStarscream.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RxStarscream.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:RxStarscream.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/RxStarscream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RxStarscream.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift",
+      "state" : {
+        "revision" : "9dcaa4b333db437b0fbfaf453fad29069044a8b4",
+        "version" : "6.6.0"
+      }
+    },
+    {
+      "identity" : "starscream",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daltoniam/Starscream",
+      "state" : {
+        "revision" : "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
+        "version" : "4.0.6"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream-macOS.xcscheme
+++ b/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream-macOS.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "98D95A3E204F7E9A00159C45"
+            BuildableName = "RxStarscream_macOS.framework"
+            BlueprintName = "RxStarscream-macOS"
+            ReferencedContainer = "container:RxStarscream.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "98D95A3E204F7E9A00159C45"
-            BuildableName = "RxStarscream_macOS.framework"
-            BlueprintName = "RxStarscream-macOS"
-            ReferencedContainer = "container:RxStarscream.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:RxStarscream.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream.xcscheme
+++ b/RxStarscream.xcodeproj/xcshareddata/xcschemes/RxStarscream.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E46D00251CFF22200054DF1F"
+            BuildableName = "RxStarscream.framework"
+            BlueprintName = "RxStarscream"
+            ReferencedContainer = "container:RxStarscream.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E46D00251CFF22200054DF1F"
-            BuildableName = "RxStarscream.framework"
-            BlueprintName = "RxStarscream"
-            ReferencedContainer = "container:RxStarscream.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:RxStarscream.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/RxStarscreamTests/RxStarscreamTests.swift
+++ b/RxStarscreamTests/RxStarscreamTests.swift
@@ -36,6 +36,7 @@ class RxStarscreamTests: XCTestCase {
     private var connectedObserver: TestableObserver<Bool>!
     private var pongObserver: TestableObserver<WebSocketEvent>!
     private var responseObserver: TestableObserver<WebSocketEvent>!
+    private var binaryObserver: TestableObserver<WebSocketEvent>!
     private var socket: WebSocket!
 
     let disposeBag = DisposeBag()
@@ -71,6 +72,22 @@ class RxStarscreamTests: XCTestCase {
     }
     
     //TODO: Binary test case.
+    func testBinary() {
+        let scheuler = TestScheduler(initialClock: 0)
+        binaryObserver = scheuler.createObserver(WebSocketEvent.self)
+        
+        let binaryEvent = WebSocketEvent.binary(Data())
+        
+        socket.rx.response
+            .subscribe(binaryObserver)
+            .disposed(by: disposeBag)
+        
+        XCTAssertNotNil(socket.delegate)
+        
+        socket.delegate?.didReceive(event: binaryEvent, client: socket)
+        XCTAssertEqual(self.binaryObserver.events.count, 1)
+        XCTAssertEqual(self.binaryObserver.events[0].value.element!, binaryEvent)
+    }
 
     func testPongMessage() {
         let scheduler = TestScheduler(initialClock: 0)

--- a/RxStarscreamTests/RxStarscreamTests.swift
+++ b/RxStarscreamTests/RxStarscreamTests.swift
@@ -18,11 +18,11 @@ public func ==(lhs: WebSocketEvent, rhs: WebSocketEvent) -> Bool {
     switch (lhs, rhs) {
     case (.connected, .connected):
         return true
-    case (.disconnected(let lhsError), .disconnected(let rhsError)):
-        return lhsError?.localizedDescription == rhsError?.localizedDescription
-    case (.message(let lhsMsg), .message(let rhsMsg)):
-        return lhsMsg == rhsMsg
-    case (.data(let lhsData), .data(let rhsData)):
+    case (.disconnected, .disconnected):
+        return true
+    case (.text(let lhsText), .text(let rhsText)):
+        return lhsText == rhsText
+    case (.binary(let lhsData), .binary(let rhsData)):
         return lhsData == rhsData
     case (.pong, .pong):
         return true
@@ -43,7 +43,7 @@ class RxStarscreamTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        socket = WebSocket(url: URL(string: "wss://echo.websocket.org")!)
+        socket = WebSocket(request: URLRequest(url: URL(string: "wss://echo.websocket.org")!))
         continueAfterFailure = false
     }
 
@@ -62,28 +62,31 @@ class RxStarscreamTests: XCTestCase {
         
         XCTAssertTrue(socket.delegate != nil, "delegate should be set")
         
-        socket.delegate!.websocketDidConnect(socket: socket)
-        socket.delegate!.websocketDidDisconnect(socket: socket, error: nil)
+        socket.delegate!.didReceive(event: .connected([:]), client: socket)
+        socket.delegate!.didReceive(event: .disconnected("", UInt16.zero), client: socket)
 
         XCTAssertEqual(self.connectedObserver.events.count, 2)
         XCTAssertEqual(self.connectedObserver.events[0].value.element!, true)
         XCTAssertEqual(self.connectedObserver.events[1].value.element!, false)
     }
+    
+    //TODO: Binary test case.
 
     func testPongMessage() {
         let scheduler = TestScheduler(initialClock: 0)
         pongObserver = scheduler.createObserver(WebSocketEvent.self)
+        
+        let pongEvent = WebSocketEvent.pong(Data())
 
         socket.rx.response
                 .subscribe(pongObserver)
                 .disposed(by: disposeBag)
         
-        XCTAssertTrue(socket.pongDelegate != nil, "pongDelegate should be set")
-        
-        socket.pongDelegate!.websocketDidReceivePong(socket: socket, data: Data())
+        XCTAssertNotNil(socket.delegate)
 
+        socket.delegate?.didReceive(event: pongEvent, client: socket)
         XCTAssertEqual(self.pongObserver.events.count, 1)
-        XCTAssertEqual(self.pongObserver.events[0].value.element!, WebSocketEvent.pong)
+        XCTAssertEqual(self.pongObserver.events[0].value.element!, pongEvent)
     }
 
     func testMessageResponse() {
@@ -98,9 +101,10 @@ class RxStarscreamTests: XCTestCase {
         
         XCTAssertTrue(socket.delegate != nil, "delegate should be set")
 
-        socket.delegate!.websocketDidReceiveMessage(socket: socket, text: sentMessage)
+        socket.delegate!.didReceive(event: .text(sentMessage), client: socket)
         
         XCTAssertEqual(self.responseObserver.events.count, 1)
-        XCTAssertEqual(WebSocketEvent.message(sentMessage), self.responseObserver.events[0].value.element!)
+        XCTAssertEqual(WebSocketEvent.text(sentMessage), self.responseObserver.events[0].value.element!)
     }
 }
+

--- a/RxStarscreamTests/RxStarscreamTests.swift
+++ b/RxStarscreamTests/RxStarscreamTests.swift
@@ -71,7 +71,6 @@ class RxStarscreamTests: XCTestCase {
         XCTAssertEqual(self.connectedObserver.events[1].value.element!, false)
     }
     
-    //TODO: Binary test case.
     func testBinary() {
         let scheuler = TestScheduler(initialClock: 0)
         binaryObserver = scheuler.createObserver(WebSocketEvent.self)

--- a/SampleApp/ViewController.swift
+++ b/SampleApp/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     @IBOutlet fileprivate weak var pongButton: UIBarButtonItem!
 
     private let disposeBag = DisposeBag()
-    private let socket = WebSocket(url: URL(string: "wss://echo.websocket.org")!)
+    private let socket = WebSocket(request: URLRequest(url: URL(string: "wss://echo.websocket.org")!))
     private let writeSubject = PublishSubject<String>()
     
     override func viewDidLoad() {
@@ -38,14 +38,26 @@ class ViewController: UIViewController {
                 switch response {
                 case .connected:
                     return "Connected\n"
-                case .disconnected(let error):
+                case .disconnected(let error, _):
                     return "Disconnected with error: \(String(describing: error)) \n"
-                case .message(let msg):
-                    return "RESPONSE (Message): \(msg) \n"
-                case .data(let data):
+                case .text(let text):
+                    return "RESPONSE (Message): \(text) \n"
+                case .binary(let data):
                     return  "RESPONSE (Data): \(data) \n"
                 case .pong:
                     return "RESPONSE (Pong)"
+                case .ping:
+                    return "PING \n"
+                case .error(let error):
+                    return error?.localizedDescription ?? "Unknow error \n"
+                case .viabilityChanged(let changed):
+                    return "Viability changed: \(changed) \n"
+                case .reconnectSuggested(let suggested):
+                    return "Reconnect suggested: \(suggested) \n"
+                case .cancelled:
+                    return "Cancelled \n"
+                case .peerClosed:
+                    return "Peer closed \n"
                 }
         }
         


### PR DESCRIPTION
- Update dependencies.
- Fix SampleApp build failed on M1. (undefined symbol) 
- Support Swift Package Manager for installation.
- Bump version to v0.11.0.